### PR TITLE
Fixed crashes when the same function is hooked twice

### DIFF
--- a/lib/arm64/dis-main.inc.h
+++ b/lib/arm64/dis-main.inc.h
@@ -1,11 +1,11 @@
 static INLINE void P(adrlabel_label_unk_Xd_1_ADR)(tdis_ctx ctx, struct bitslice Xd, struct bitslice label) {
-    return P(pcrel)(ctx, ctx->base.pc + sext(bs_get(label, ctx->base.op), 22),
+    return P(pcrel)(ctx, ctx->base.pc + sext(bs_get(label, ctx->base.op), 21),
                     (struct arch_pcrel_info) {bs_get(Xd, ctx->base.op), PLM_ADR});
 }
 static INLINE void P(adrplabel_label_unk_Xd_1_ADRP)(tdis_ctx ctx, struct bitslice Xd, struct bitslice label) {
     return P(pcrel)(ctx,
                     (ctx->base.pc & ~0xfff) +
-                    (sext(bs_get(label, ctx->base.op), 22) << 12),
+                    (sext(bs_get(label, ctx->base.op), 21) << 12),
                     (struct arch_pcrel_info) {bs_get(Xd, ctx->base.op), PLM_ADR});
 }
 static INLINE void P(am_b_target_addr_B_1_B)(tdis_ctx ctx, struct bitslice addr) {

--- a/lib/dis.h
+++ b/lib/dis.h
@@ -43,7 +43,7 @@ struct bitslice {
     const struct bitslice_run *runs;
 };
 
-static inline int sext(unsigned val, int bits) {
+static inline uint_tptr sext(unsigned val, int bits) {
     return val & (1 << (bits - 1)) ? ((int)val - (1 << bits)) : (int)val;
 }
 


### PR DESCRIPTION
sext() was converting to 32bit then being shifted 12 bits, giving 33 significant bits.  Changed the type of sext to a value that will be 64bit on 64bit arch.  Also corrected the argument for sext to be 21 instead of 22