### PR TITLE
Stop using x18 on arm64

### DIFF
--- a/lib/arm64/arch-dis.h
+++ b/lib/arm64/arch-dis.h
@@ -28,7 +28,7 @@ static inline void arch_dis_ctx_init(struct arch_dis_ctx *ctx) {
 }
 
 static inline int arm64_get_unwritten_temp_reg(struct arch_dis_ctx *ctx) {
-    uint32_t avail = ~ctx->regs_possibly_written & ((1 << 19) - (1 << 9));
+    uint32_t avail = ~ctx->regs_possibly_written & ((1 << 18) - (1 << 9));
     if (!avail)
         __builtin_abort();
     return 31 - __builtin_clz(avail);


### PR DESCRIPTION
See comex's comment here: https://github.com/comex/substitute/issues/27

tl;dr of that is [x18 isn't supposed to be used in userland](https://developer.apple.com/library/archive/documentation/Xcode/Conceptual/iPhoneOSABIReference/Articles/ARM64FunctionCallingConventions.html#//apple_ref/doc/uid/TP40013702-SW1).

This caused some hooked function pointers to randomly be overwritten with 0x0,
causing a crash. Most notably was the function AudioUnitRender in mediaserverd.

Affected tweaks include EQE, MitsuhaXI, and Anemone.